### PR TITLE
Add pidparams

### DIFF
--- a/example/lctupletof.xml
+++ b/example/lctupletof.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<!-- ?xml-stylesheet type="text/xsl" href="http://ilcsoft.desy.de/marlin/marlin.xsl"? -->
+<!-- ?xml-stylesheet type="text/xsl" href="marlin.xsl"? -->
+
+<!-- Loading shared library : /Users/fgaede/marlin/mymarlin/lib/libmymarlin.0.1.0.dylib (libmymarlin.dylib)-->
+
+<!--##########################################
+    #                                        #
+    #     Example steering file for marlin   #
+    #     writes an LCTuple with PandoraPFOs #
+    #     and TOF parameters                 #
+    ##########################################-->
+
+
+<marlin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://ilcsoft.desy.de/marlin/marlin.xsd">
+ <execute>
+  <processor name="MyAIDAProcessor"/>
+  <processor name="MyLCTuple"/>  
+ </execute>
+
+ <global>
+  <parameter name="LCIOInputFiles"> infile.slcio </parameter>
+  <!-- limit the number of processed records (run+evt): -->  
+  <parameter name="MaxRecordNumber" value="10" />  
+  <parameter name="SkipNEvents" value="0"/>  
+  <parameter name="SupressCheck" value="false" />  
+  <parameter name="GearXMLFile"></parameter>  
+  <parameter name="Verbosity" options="DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT">DEBUG  </parameter> 
+  <parameter name="RandomSeed" value="1234567890" />
+ </global>
+
+ <processor name="MyAIDAProcessor" type="AIDAProcessor">
+  <parameter name="FileName" type="string">lctuple </parameter>
+  <parameter name="FileType" type="string">root </parameter>
+ </processor>
+
+ <processor name="MyLCTuple" type="LCTuple">
+ <!--LCTuple creates a ROOT TTRee with a column wise ntuple from LCIO collections ....-->
+
+ <!--Name of the ReconstructedParticle collection-->
+  <parameter name="RecoParticleCollection" type="string" lcioInType="ReconstructedParticle"> PandoraPFOs </parameter>
+
+  <!--Definition of PID branches added to the ReconstructedParticle branches - for every algorithm:
+      Algorithm:Name branchPrefix Parameter0 branch0  Parameter1 branch1  Parameter2 branch2 ...-->
+  <parameter name="PIDBranchDefinition" type="StringVec">
+    Algorithm:TOFEstimators0ps tof0
+    TOFFirstHit TOFClosestHits TOFClosestHitsError TOFFlightLength TOFLastTrkHit TOFLastTrkHitFlightLength
+    fh          ch             che                 len             th            thl
+    Algorithm:TOFEstimators10ps tof10
+    TOFFirstHit TOFClosestHits TOFClosestHitsError TOFFlightLength TOFLastTrkHit TOFLastTrkHitFlightLength
+    fh          ch             che                 len             th            thl
+    Algorithm:TOFEstimators50ps tof50
+    TOFFirstHit TOFClosestHits TOFClosestHitsError TOFFlightLength TOFLastTrkHit TOFLastTrkHitFlightLength
+    fh          ch             che                 len             th            thl
+  </parameter>
+  <!-- can also add other PID algorithms, eg: 
+    Algorithm:dEdxPID dedx
+    electronLikelihood muonLikelihood  pionLikelihood kaonLikelihood protonLikelihood hadronLikelihood
+    lhe                lhmu            lhpi           lhk            lhp              lhhad
+ -->
+
+  
+
+  <!--verbosity level of this processor ("DEBUG0-4,MESSAGE0-4,WARNING0-4,ERROR0-4,SILENT")-->
+  <parameter name="Verbosity" type="string">DEBUG5 </parameter>
+</processor>
+
+
+</marlin>

--- a/include/LCTuple.h
+++ b/include/LCTuple.h
@@ -8,6 +8,7 @@
 #include "MCParticleFromRelationBranches.h"
 
 #include "JetBranches.h"
+#include "PIDBranches.h"
 
 
 using namespace lcio ;
@@ -69,65 +70,66 @@ class LCTuple : public Processor {
 
   /** Input collection name.
    */
-  std::string _mcpColName ;
-  std::string _mcpRemoveOverlayColName ;
-  std::string _recColName ;
-  std::string _jetColName ;
-  std::string _isolepColName ;  
-  std::string _trkColName ;
-  std::string _cluColName ;
-  std::string _sthColName ;
-  std::string _trhColName ;
-  std::string _schColName ;
-  std::string _cahColName ;
-  std::string _vtxColName ;
-  std::string _pfoRelName ;
-  std::string _relName ;
+  std::string _mcpColName {};
+  std::string _mcpRemoveOverlayColName {};
+  std::string _recColName {};
+  std::string _jetColName {};
+  std::string _isolepColName {};  
+  std::string _trkColName {};
+  std::string _cluColName {};
+  std::string _sthColName {};
+  std::string _trhColName {};
+  std::string _schColName {};
+  std::string _cahColName {};
+  std::string _vtxColName {};
+  std::string _pfoRelName {};
+  std::string _relName {};
 
 
 
-  bool _mcpColWriteParameters ;
-  bool _recColWriteParameters ;
-  bool _jetColWriteParameters ;
-  bool _isolepColWriteParameters ; 
-  bool _trkColWriteParameters ;
-  bool _cluColWriteParameters ;
-  bool _sthColWriteParameters ;
-  bool _trhColWriteParameters ;
-  bool _schColWriteParameters ;
-  bool _cahColWriteParameters ;
-  bool _vtxColWriteParameters ;
+  bool _mcpColWriteParameters {};
+  bool _recColWriteParameters {};
+  bool _jetColWriteParameters {};
+  bool _isolepColWriteParameters {}; 
+  bool _trkColWriteParameters {};
+  bool _cluColWriteParameters {};
+  bool _sthColWriteParameters {};
+  bool _trhColWriteParameters {};
+  bool _schColWriteParameters {};
+  bool _cahColWriteParameters {};
+  bool _vtxColWriteParameters {};
 
 
-  bool _jetColExtraParameters ;                 /* Enables writing extra jet parameters */
-  bool _jetColTaggingParameters ;               /* Enables writing jet tagging parameters */
+  bool _jetColExtraParameters {};                 /* Enables writing extra jet parameters */
+  bool _jetColTaggingParameters {};               /* Enables writing jet tagging parameters */
 
 
-  StringVec _relColNames ;
-  StringVec _relPrefixes ;
+  StringVec _relColNames {};
+  StringVec _relPrefixes {};
 
-  TTree* _tree ;
+  TTree* _tree {};
 
-  CWBranchesSet* _evtBranches ;
-  CollectionBranches* _mcpBranches ;
-  CollectionBranches* _mcpremoveoverlayBranches ;
-  CollectionBranches* _recBranches ;
-//  CollectionBranches* _jetBranches ;
-  JetBranches* _jetBranches ;
-  CollectionBranches* _isolepBranches ;
-  CollectionBranches* _trkBranches ;
-  CollectionBranches* _cluBranches ;
-  CollectionBranches* _sthBranches ;
-  CollectionBranches* _trhBranches ;
-  CollectionBranches* _schBranches ;
-  CollectionBranches* _cahBranches ;
-  CollectionBranches* _vtxBranches ;
-  MCParticleFromRelationBranches* _mcRelBranches ;
+  CWBranchesSet* _evtBranches {};
+  CollectionBranches* _mcpBranches {};
+  CollectionBranches* _mcpremoveoverlayBranches {};
+  CollectionBranches* _recBranches {};
+//  CollectionBranches* _jetBranches {};
+  JetBranches* _jetBranches {};
+  CollectionBranches* _isolepBranches {};
+  CollectionBranches* _trkBranches {};
+  CollectionBranches* _cluBranches {};
+  CollectionBranches* _sthBranches {};
+  CollectionBranches* _trhBranches {};
+  CollectionBranches* _schBranches {};
+  CollectionBranches* _cahBranches {};
+  CollectionBranches* _vtxBranches {};
+  MCParticleFromRelationBranches* _mcRelBranches {};
   
-  std::vector<CWBranchesSet*> _relBranchesVec ;
+  std::vector<PIDBranches*> _pidBranchesVec {};
+  std::vector<CWBranchesSet*> _relBranchesVec {};
   
-  int _nRun ;
-  int _nEvt ;
+  int _nRun {};
+  int _nEvt {};
 } ;
 
 #endif

--- a/include/LCTuple.h
+++ b/include/LCTuple.h
@@ -37,6 +37,13 @@ class CollectionBranches;
 
 class LCTuple : public Processor {
   
+  struct PIDBranchDef{
+    std::string algoName{} ;
+    std::string prefix{} ;
+    std::vector<std::string> pNames{} ;
+    std::vector<std::string> bNames{} ;
+  } ;
+
  public:
   
   virtual Processor*  newProcessor() { return new LCTuple ; }
@@ -67,6 +74,8 @@ class LCTuple : public Processor {
   
   
  protected:
+
+  void decodePIDBranchDefinitions() ;
 
   /** Input collection name.
    */
@@ -107,6 +116,8 @@ class LCTuple : public Processor {
   StringVec _relColNames {};
   StringVec _relPrefixes {};
 
+  StringVec _pidBranchDefinition {};
+  
   TTree* _tree {};
 
   CWBranchesSet* _evtBranches {};
@@ -130,6 +141,8 @@ class LCTuple : public Processor {
   
   int _nRun {};
   int _nEvt {};
+
+  std::vector<PIDBranchDef> _pidBranchDefs ;
 } ;
 
 #endif

--- a/include/PIDBranches.h
+++ b/include/PIDBranches.h
@@ -16,8 +16,12 @@ namespace EVENT{
 }
 
 /** PIDBranches holds branches for ParticleID objects attached to the  elements of the ReconstructedParticle collection
+ *  These branches have to run parallel to the ReconstructedParticle branches.
+ *  The actual branch names and parameters have to be defined outside of the class, e.g. in 
+ *  the LCTuple processor parameter PIDBranchDefinition.
  * 
  * @author F. Gaede, DESY
+ * @date May, 2018
  * @version $Id$
  */
 

--- a/include/PIDBranches.h
+++ b/include/PIDBranches.h
@@ -1,0 +1,59 @@
+#ifndef PIDBranches_h
+#define PIDBranches_h 1
+
+#include "LCTupleConf.h" 
+
+#include "CollectionBranches.h"
+#include <vector>
+#include <array>
+#include <string>
+
+class TTree ;
+
+namespace EVENT{
+  class LCCollection ;
+  class LCCEvent ;
+}
+
+/** PIDBranches holds branches for ParticleID objects attached to the  elements of the ReconstructedParticle collection
+ * 
+ * @author F. Gaede, DESY
+ * @version $Id$
+ */
+
+class PIDBranches : public CollectionBranches {
+  
+public:
+  
+  PIDBranches() {} ;
+  
+  void defineBranches(const std::string& algorithmName,
+		      const std::vector<std::string>& paramNames,
+		      const std::vector<std::string>& branchNames) ;
+
+  virtual void initBranches( TTree* tree, const std::string& prefix="" ) ;
+  
+  virtual void fill(const EVENT::LCCollection* col, EVENT::LCEvent* evt ) ;
+  
+  virtual ~PIDBranches() {} ;
+  
+
+private:
+  std::string _algorithmName{} ;
+  std::vector<std::string> _paramNames{} ;
+  std::vector<std::string> _branchNames{} ;
+  
+  std::array<int  , LCT_RECOPARTICLE_MAX > _rcpityp{} ;
+  std::array<int  , LCT_RECOPARTICLE_MAX > _rcpipdg{} ;
+  std::array<float, LCT_RECOPARTICLE_MAX > _rcpillh{} ;
+  std::array<int  , LCT_RECOPARTICLE_MAX > _rcpialg{} ;
+
+  std::vector< std::array< float,LCT_RECOPARTICLE_MAX > > _rcpiparam{} ;
+
+
+} ;
+
+#endif
+
+
+

--- a/src/LCTuple.cc
+++ b/src/LCTuple.cc
@@ -329,7 +329,18 @@ void LCTuple::init() {
     _recBranches =  new RecoParticleBranches ;
     _recBranches->writeParameters(_recColWriteParameters);
     _recBranches->initBranches( _tree ) ;
+
+    std::vector<std::string> pNames = {"TOFFirstHit", "TOFClosestHits", "TOFClosestHitsError", "TOFFlightLength", "TOFLastTrkHit", "TOFLastTrkHitFlightLength" } ;
+    std::vector<std::string> bNames = {"fh", "ch", "che", "len", "th", "thl" } ;
+
+    _pidBranchesVec.push_back( new PIDBranches ) ;
+    PIDBranches* pidb = _pidBranchesVec.back() ;
+    
+    pidb->defineBranches( "TOFEstimators50ps", pNames, bNames ) ;
+    pidb->initBranches( _tree , "tof50_" ) ;
+
   }
+  
 
   if( _jetColName.size() ) {
     _jetBranches = new JetBranches ;
@@ -506,8 +517,12 @@ void LCTuple::processEvent( LCEvent * evt ) {
   
   if( mcpRemoveOverlayCol ) _mcpremoveoverlayBranches->fill( mcpRemoveOverlayCol , evt ) ;
 
-  if( recCol ) _recBranches->fill( recCol , evt ) ;
-  
+  if( recCol ) {
+    _recBranches->fill( recCol , evt ) ;
+
+    for( auto pidb : _pidBranchesVec ) pidb->fill( recCol , evt ) ;
+  }
+
   if( jetCol ) _jetBranches->fill (jetCol , evt ) ;		// @ebrahimi:  removed: && jetCol->getNumberOfElements()==2
   
   if( isolepCol ) _isolepBranches->fill (isolepCol , evt ) ;
@@ -577,6 +592,8 @@ void LCTuple::end(){
   delete _trkBranches ; 
   delete _vtxBranches ; 
   delete _mcRelBranches ;
+  
+  for( auto pidb : _pidBranchesVec ) delete pidb ;
   
   for(unsigned i=0 , nRel =_relBranchesVec.size() ; i <nRel ; 
       delete _relBranchesVec[i++] )  ;

--- a/src/PIDBranches.cc
+++ b/src/PIDBranches.cc
@@ -1,0 +1,88 @@
+#include "PIDBranches.h"
+#include "Exceptions.h"
+
+#include "lcio.h"
+#include "EVENT/LCCollection.h"
+#include "EVENT/ReconstructedParticle.h"
+#include "EVENT/Vertex.h"
+#include <UTIL/PIDHandler.h>
+
+#include "TTree.h"
+
+void PIDBranches::defineBranches(const std::string& algorithmName,
+				 const std::vector<std::string>& paramNames,
+				 const std::vector<std::string>& branchNames) {
+  
+  if( paramNames.size() != branchNames.size() ){
+    
+    throw lcio::Exception("PIDBranches::setParameterNames inconsistent parameter and branch name vector lenghts !" ) ; 
+  }
+  _algorithmName = algorithmName ;
+  _paramNames    = paramNames ;
+  _branchNames   = branchNames ;
+  _rcpiparam.resize( _branchNames.size() ) ;
+}
+
+void PIDBranches::initBranches( TTree* tree, const std::string& pre){
+
+  if( tree == 0 ){
+
+    throw lcio::Exception("  PIDBranches::initBranches - invalid tree pointer !!! " ) ;
+  }
+  tree->Branch( (pre+"rcpityp").c_str() , _rcpityp.data() , (pre+"rcpityp[nrec]/I").c_str() ) ;
+  tree->Branch( (pre+"rcpipdg").c_str() , _rcpipdg.data() , (pre+"rcpipdg[nrec]/I").c_str() ) ;
+  tree->Branch( (pre+"rcpillh").c_str() , _rcpillh.data() , (pre+"rcpillh[nrec]/F").c_str() ) ;
+  tree->Branch( (pre+"rcpialg").c_str() , _rcpialg.data() , (pre+"rcpialg[nrec]/I").c_str() ) ;
+  
+  for(unsigned i=0,N=_branchNames.size(); i<N; ++i){
+
+    tree->Branch( (pre+_branchNames[i]).c_str() , _rcpiparam[i].data() , (pre+_branchNames[i]+"[nrec]/F").c_str() ) ;
+  }
+  
+}
+  
+
+void PIDBranches::fill(const EVENT::LCCollection* col, EVENT::LCEvent* ){
+  
+  if( !col ) return ;
+
+  if( col->getTypeName() != lcio::LCIO::RECONSTRUCTEDPARTICLE ){
+    
+    std::string exStr("PIDBranches::fill: invalid collection type : " ) ;
+    
+    throw EVENT::Exception( exStr + col->getTypeName() ) ; 
+  }
+  
+  int nrec  = col->getNumberOfElements() ;
+  
+  lcio::PIDHandler pidh( col );
+  int algoID       = pidh.getAlgorithmID( _algorithmName );
+  
+  std::vector<int> algoIndices ;
+  algoIndices.reserve(_paramNames.size() ) ; 
+
+  for( auto name : _paramNames ){
+    algoIndices.push_back(  pidh.getParameterIndex(algoID, name ) ) ;
+  }
+  
+  //------  fill the requested PID information for the Reconstructed particle ----------------------------
+
+  for(int i=0 ; i < nrec ; ++i){
+    
+    lcio::ReconstructedParticle* rec = static_cast<lcio::ReconstructedParticle*>( col->getElementAt(i) ) ;
+
+    const ParticleID& pid    = pidh.getParticleID( rec , algoID ) ;
+    const FloatVec&   params = pid.getParameters() ;
+
+    _rcpityp[i] = pid.getType() ;
+    _rcpipdg[i] = pid.getPDG() ;
+    _rcpillh[i] = pid.getLikelihood() ;
+    _rcpialg[i] = pid.getAlgorithmType() ;
+    
+    for(unsigned j=0,N=_branchNames.size(); j<N; ++j){
+      _rcpiparam[j][i] = ( params.empty() ? -1 : params[ algoIndices[j] ] ) ;
+    }
+
+  }
+
+}

--- a/src/PIDBranches.cc
+++ b/src/PIDBranches.cc
@@ -9,6 +9,8 @@
 
 #include "TTree.h"
 
+using namespace lcio ;
+
 void PIDBranches::defineBranches(const std::string& algorithmName,
 				 const std::vector<std::string>& paramNames,
 				 const std::vector<std::string>& branchNames) {


### PR DESCRIPTION

BEGINRELEASENOTES
- add possibility to store arbitrary PID parameters for the ReconstructedParticle branch
    - parameter and branches need to be defined in  `PIDBranchDefinition` parameter of LCTuple
    - see [../example/lctupletof.xml](../example/lctupletof.xml) for details
   

ENDRELEASENOTES