### PR TITLE
Update the minimum CMake version to 3.10 to allow building with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################
 # cmake file for building Marlin example Package
 # @author Jan Engels, Desy IT
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)
 ########################################################
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Update the minimum CMake version to 3.10 to allow building with CMake 4

ENDRELEASENOTES

I just built with and without this and there are no warnings about any policy. Let's try this one in the nightlies.